### PR TITLE
Add more OIDs

### DIFF
--- a/anssi/curves.json
+++ b/anssi/curves.json
@@ -6,6 +6,7 @@
       "name": "FRP256v1",
       "category": "anssi",
       "desc": "",
+      "oid": "1.2.250.1.223.101.256.1",
       "field": {
         "type": "Prime",
         "p": "0xf1fd178c0b3ad58f10126de8ce42435b3961adbcabc8ca6de8fcf353d86e9c03",

--- a/nist/curves.json
+++ b/nist/curves.json
@@ -6,6 +6,7 @@
       "name": "P-192",
       "category": "nist",
       "desc": "",
+      "oid": "1.2.840.10045.3.1.1",
       "field": {
         "type": "Prime",
         "p": "0xfffffffffffffffffffffffffffffffeffffffffffffffff",
@@ -82,6 +83,7 @@
       "name": "P-224",
       "category": "nist",
       "desc": "",
+      "oid": "1.3.132.0.33",
       "field": {
         "type": "Prime",
         "p": "0xffffffffffffffffffffffffffffffff000000000000000000000001",
@@ -144,6 +146,7 @@
       "name": "P-256",
       "category": "nist",
       "desc": "",
+      "oid": "1.2.840.10045.3.1.7",
       "field": {
         "type": "Prime",
         "p": "0xffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
@@ -210,6 +213,7 @@
       "name": "P-384",
       "category": "nist",
       "desc": "",
+      "oid": "1.3.132.0.34",
       "field": {
         "type": "Prime",
         "p": "0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff",
@@ -249,6 +253,7 @@
       "name": "P-521",
       "category": "nist",
       "desc": "",
+      "oid": "1.3.132.0.35",
       "field": {
         "type": "Prime",
         "p": "0x01ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
@@ -288,6 +293,7 @@
       "name": "K-163",
       "category": "nist",
       "desc": "Koblitz curve.",
+      "oid": "1.3.132.0.1",
       "field": {
         "type": "Binary",
         "poly": [
@@ -352,6 +358,7 @@
       "name": "B-163",
       "category": "nist",
       "desc": "",
+      "oid": "1.3.132.0.15",
       "field": {
         "type": "Binary",
         "poly": [
@@ -418,6 +425,7 @@
       "name": "K-233",
       "category": "nist",
       "desc": "Koblitz curve.",
+      "oid": "1.3.132.0.26",
       "field": {
         "type": "Binary",
         "poly": [
@@ -475,6 +483,7 @@
       "name": "B-233",
       "category": "nist",
       "desc": "",
+      "oid": "1.3.132.0.27",
       "field": {
         "type": "Binary",
         "poly": [
@@ -534,6 +543,7 @@
       "name": "K-283",
       "category": "nist",
       "desc": "Koblitz curve.",
+      "oid": "1.3.132.0.16",
       "field": {
         "type": "Binary",
         "poly": [
@@ -599,6 +609,7 @@
       "name": "B-283",
       "category": "nist",
       "desc": "",
+      "oid": "1.3.132.0.17",
       "field": {
         "type": "Binary",
         "poly": [
@@ -665,6 +676,7 @@
       "name": "K-409",
       "category": "nist",
       "desc": "Koblitz curve.",
+      "oid": "1.3.132.0.36",
       "field": {
         "type": "Binary",
         "poly": [
@@ -720,6 +732,7 @@
       "name": "B-409",
       "category": "nist",
       "desc": "",
+      "oid": "1.3.132.0.37",
       "field": {
         "type": "Binary",
         "poly": [
@@ -776,6 +789,7 @@
       "name": "K-571",
       "category": "nist",
       "desc": "Koblitz curve.",
+      "oid": "1.3.132.0.38",
       "field": {
         "type": "Binary",
         "poly": [
@@ -839,6 +853,7 @@
       "name": "B-571",
       "category": "nist",
       "desc": "",
+      "oid": "1.3.132.0.39",
       "field": {
         "type": "Binary",
         "poly": [

--- a/x962/curves.json
+++ b/x962/curves.json
@@ -411,6 +411,7 @@
       "name": "c2pnb176w1",
       "category": "x962",
       "desc": "",
+      "oid": "1.2.840.10045.3.0.4",
       "field": {
         "type": "Binary",
         "bits": 176,
@@ -1028,6 +1029,7 @@
       "name": "c2pnb304w1",
       "category": "x962",
       "desc": "",
+      "oid": "1.2.840.10045.3.0.17",
       "field": {
         "type": "Binary",
         "bits": 304,

--- a/x963/curves.json
+++ b/x963/curves.json
@@ -7,6 +7,7 @@
       "name": "ansit163k1",
       "category": "x963",
       "desc": "",
+      "oid": "1.3.132.0.1",
       "field": {
         "type": "Binary",
         "poly": [

--- a/x963/curves.json
+++ b/x963/curves.json
@@ -58,6 +58,7 @@
       "name": "ansit163r1",
       "category": "x963",
       "desc": "",
+      "oid": "1.3.132.0.2",
       "field": {
         "type": "Binary",
         "poly": [
@@ -114,6 +115,7 @@
       "name": "ansit163r2",
       "category": "x963",
       "desc": "",
+      "oid": "1.3.132.0.15",
       "field": {
         "type": "Binary",
         "poly": [
@@ -170,6 +172,7 @@
       "name": "ansit193r1",
       "category": "x963",
       "desc": "",
+      "oid": "1.3.132.0.24",
       "field": {
         "type": "Binary",
         "bits": 193,
@@ -217,6 +220,7 @@
       "name": "ansit193r2",
       "category": "x963",
       "desc": "",
+      "oid": "1.3.132.0.25",
       "field": {
         "type": "Binary",
         "bits": 193,
@@ -264,6 +268,7 @@
       "name": "ansit233k1",
       "category": "x963",
       "desc": "",
+      "oid": "1.3.132.0.26",
       "field": {
         "type": "Binary",
         "poly": [
@@ -313,6 +318,7 @@
       "name": "ansit233r1",
       "category": "x963",
       "desc": "",
+      "oid": "1.3.132.0.27",
       "field": {
         "type": "Binary",
         "poly": [
@@ -362,6 +368,7 @@
       "name": "ansit239k1",
       "category": "x963",
       "desc": "",
+      "oid": "1.3.132.0.3",
       "field": {
         "type": "Binary",
         "bits": 239,
@@ -409,6 +416,7 @@
       "name": "ansit283k1",
       "category": "x963",
       "desc": "",
+      "oid": "1.3.132.0.16",
       "field": {
         "type": "Binary",
         "bits": 283,
@@ -465,6 +473,7 @@
       "name": "ansit283r1",
       "category": "x963",
       "desc": "",
+      "oid": "1.3.132.0.17",
       "field": {
         "type": "Binary",
         "bits": 283,
@@ -521,6 +530,7 @@
       "name": "ansit409k1",
       "category": "x963",
       "desc": "",
+      "oid": "1.3.132.0.36",
       "field": {
         "type": "Binary",
         "poly": [
@@ -569,6 +579,7 @@
       "name": "ansit409r1",
       "category": "x963",
       "desc": "",
+      "oid": "1.3.132.0.37",
       "field": {
         "type": "Binary",
         "poly": [
@@ -617,6 +628,7 @@
       "name": "ansit571k1",
       "category": "x963",
       "desc": "",
+      "oid": "1.3.132.0.38",
       "field": {
         "type": "Binary",
         "poly": [
@@ -673,6 +685,7 @@
       "name": "ansit571r1",
       "category": "x963",
       "desc": "",
+      "oid": "1.3.132.0.39",
       "field": {
         "type": "Binary",
         "poly": [
@@ -729,6 +742,7 @@
       "name": "ansip160k1",
       "category": "x963",
       "desc": "",
+      "oid": "1.3.132.0.9",
       "field": {
         "type": "Prime",
         "p": "0xfffffffffffffffffffffffffffffffeffffac73",
@@ -761,6 +775,7 @@
       "name": "ansip160r1",
       "category": "x963",
       "desc": "",
+      "oid": "1.3.132.0.8",
       "field": {
         "type": "Prime",
         "p": "0xffffffffffffffffffffffffffffffff7fffffff",
@@ -794,6 +809,7 @@
       "name": "ansip160r2",
       "category": "x963",
       "desc": "",
+      "oid": "1.3.132.0.30",
       "field": {
         "type": "Prime",
         "p": "0xfffffffffffffffffffffffffffffffeffffac73",
@@ -826,6 +842,7 @@
       "name": "ansip192k1",
       "category": "x963",
       "desc": "",
+      "oid": "1.3.132.0.31",
       "field": {
         "type": "Prime",
         "p": "0xfffffffffffffffffffffffffffffffffffffffeffffee37",
@@ -858,6 +875,7 @@
       "name": "ansip224k1",
       "category": "x963",
       "desc": "",
+      "oid": "1.3.132.0.32",
       "field": {
         "type": "Prime",
         "p": "0xfffffffffffffffffffffffffffffffffffffffffffffffeffffe56d",
@@ -890,6 +908,7 @@
       "name": "ansip224r1",
       "category": "x963",
       "desc": "",
+      "oid": "1.3.132.0.33",
       "field": {
         "type": "Prime",
         "p": "0xffffffffffffffffffffffffffffffff000000000000000000000001",
@@ -924,6 +943,7 @@
       "name": "ansip256k1",
       "category": "x963",
       "desc": "",
+      "oid": "1.3.132.0.10",
       "field": {
         "type": "Prime",
         "p": "0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
@@ -956,6 +976,7 @@
       "name": "ansip384r1",
       "category": "x963",
       "desc": "",
+      "oid": "1.3.132.0.34",
       "field": {
         "type": "Prime",
         "p": "0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff",
@@ -989,6 +1010,7 @@
       "name": "ansip521r1",
       "category": "x963",
       "desc": "",
+      "oid": "1.3.132.0.35",
       "field": {
         "type": "Prime",
         "p": "0x01ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",


### PR DESCRIPTION
Checked the OIDs in categories `secg`, `nist`, `brainpool`, `anssi`, `x962`, and `x963`

 - Where the OID existed in the alias, this was copied over
 - Missing OIDs were looked up at http://oidref.com/
